### PR TITLE
Support for user-friendly cached result wiping

### DIFF
--- a/src/pages/css/Main.css
+++ b/src/pages/css/Main.css
@@ -135,10 +135,10 @@ body {
   font-size: 48px;
 }
 
-.aom-a {
+.aom-a, .red {
   color: #c66;
 }
-.aom-m {
+.aom-m, .blue {
   color: #66c;
 }
 

--- a/src/pages/modules/MainPhase/MainPhase.js
+++ b/src/pages/modules/MainPhase/MainPhase.js
@@ -11,7 +11,7 @@ import HelpMessage from './submodules/HelpMessage';
 
 /* Custom Hooks */
 import useHelpMap from './util/useHelpMap';
-import useShiftModifier from './util/useShiftModifier';
+import useKeyModifiers from './util/useKeyModifiers';
 
 /* Utils */
 // import { ANILIST_BASE_URL, VIEWER_RELEVANT_MEDIA_QUERY_GEN } from '../util/const';
@@ -62,7 +62,7 @@ const MainPhase = ({
     transitionMainState('data-phase');
   };
 
-  const { isShifting } = useShiftModifier();
+  const { isShifting } = useKeyModifiers();
   const handleKeyPress = useCallback((e) => {
     console.log(e.key, isShifting);
     if (e.key === 'CapsLock' && isShifting) {

--- a/src/pages/modules/MainPhase/submodules/SearchPhase/__tests__/SearchPhase.test.js
+++ b/src/pages/modules/MainPhase/submodules/SearchPhase/__tests__/SearchPhase.test.js
@@ -8,18 +8,29 @@ import '@testing-library/jest-dom/extend-expect';
 import fetch from 'jest-fetch-mock';
 import SearchPhase from '../SearchPhase';
 import { SEARCH_PHASE_MOCK_RESPONSE, SEARCH_PHASE_MOCK_RESPONSE_PARTIAL } from '../../../../util/const';
+import GlobalContext from '../../../../util/GlobalContext';
 
 const setup = () => {
   const callbackFn = jest.fn();
+  const setGlobalCallbackFn = jest.fn();
   const { container } = render(
-    <SearchPhase
-      transitionCallback={callbackFn}
-      token="TOKEN"
-      type="ANIME"
-    />,
+    <GlobalContext.Provider
+      value={{
+        globalValues: {},
+        setGlobalValues: setGlobalCallbackFn,
+      }}
+    >
+      <SearchPhase
+        transitionCallback={callbackFn}
+        token="TOKEN"
+        type="ANIME"
+      />
+    </GlobalContext.Provider>,
   );
   const input = container.querySelector('input#search-input');
-  return { callbackFn, container, input };
+  return {
+    callbackFn, container, setGlobalCallbackFn, input,
+  };
 };
 
 describe('search phase tests', () => {

--- a/src/pages/modules/MainPhase/util/useHelpMap.js
+++ b/src/pages/modules/MainPhase/util/useHelpMap.js
@@ -14,13 +14,11 @@ const useHelpMap = () => {
     'search-phase': (
       <span>
         <span>Press </span>
-        <span className="aom-a bold">Enter</span>
+        <span className="red bold">Enter</span>
         <span> to submit your search, </span>
-        <span className="green bold">↑</span>
-        <span> to toggle titles, </span>
         <span className="cyan bold">← →</span>
         <span> to change pages or </span>
-        <span className="aom-m bold">F1 through F4</span>
+        <span className="blue bold">F1 through F4</span>
         <span> to select the media</span>
       </span>
     ),
@@ -29,9 +27,9 @@ const useHelpMap = () => {
         <span>Status keybinds: </span>
         <span className="green bold">U</span>
         <span> for updating existing, </span>
-        <span className="aom-m bold">C</span>
+        <span className="blue bold">C</span>
         <span> for completed, </span>
-        <span className="aom-a bold">D</span>
+        <span className="red bold">D</span>
         <span> for dropped, and </span>
         <span className="orange bold">H</span>
         <span> for something put on hold, </span>

--- a/src/pages/modules/MainPhase/util/useKeyModifiers.js
+++ b/src/pages/modules/MainPhase/util/useKeyModifiers.js
@@ -1,12 +1,15 @@
 import { useState, useEffect } from 'react';
 
-const useShiftModifier = () => {
+const useKeyModifiers = () => {
   const [isShifting, setIsShifting] = useState(false);
+  const [isCtrling, setIsCtrling] = useState(false);
   const handleKeyDown = (e) => {
     if (e.key === 'Shift') setIsShifting(true);
+    if (e.key === 'Control') setIsCtrling(true);
   };
   const handleKeyUp = (e) => {
     if (e.key === 'Shift') setIsShifting(false);
+    if (e.key === 'Control') setIsCtrling(false);
   };
   useEffect(() => {
     document.addEventListener('keydown', handleKeyDown);
@@ -17,7 +20,7 @@ const useShiftModifier = () => {
     };
   });
 
-  return { isShifting };
+  return { isShifting, isCtrling };
 };
 
-export default useShiftModifier;
+export default useKeyModifiers;

--- a/src/pages/modules/util/Alert.css
+++ b/src/pages/modules/util/Alert.css
@@ -1,12 +1,13 @@
 #alert-container {
     position: absolute;
-    top: 150px;
+    top: 50px;
     left: 0;
     transform: translateY(-40px);
     display: flex;
     width: 100%;
     align-items: center;
     justify-content: center;
+    z-index: 100;
     -webkit-transform: translateY(-40px);
     -moz-transform: translateY(-40px);
     -ms-transform: translateY(-40px);

--- a/src/pages/modules/util/Alert.js
+++ b/src/pages/modules/util/Alert.js
@@ -12,6 +12,7 @@ const Alert = () => {
         content,
         containerStyle,
         style,
+        duration = 1250,
       },
     },
     setGlobalValues,
@@ -19,19 +20,20 @@ const Alert = () => {
 
   const [cachedAlert, setCachedAlert] = useState(content);
   const alertProps = useSpring({
-    transform: `translateY(${active ? -150 : -250}%)`,
+    transform: `translateY(${active ? 0 : -50}px)`,
     opacity: active && content ? 1 : 0,
+    ...containerStyle,
   });
 
   useEffect(() => {
     if (active && content) {
       const hide = setTimeout(() => setGlobalValues({
         type: 'RESET_ALERT',
-      }), 1250);
+      }), duration);
       return () => clearTimeout(hide);
     }
     return () => {};
-  }, [active, content, setGlobalValues]);
+  }, [active, content, duration, setGlobalValues]);
 
   useEffect(() => {
     if (content) setCachedAlert(content);
@@ -42,7 +44,6 @@ const Alert = () => {
       id="alert-container"
       style={{
         ...alertProps,
-        ...containerStyle,
       }}
     >
       <div
@@ -58,4 +59,26 @@ const Alert = () => {
   );
 };
 
+export const presets = {
+  red: {
+    borderColor: '#f99',
+    backgroundColor: '#f996',
+  },
+  orange: {
+    borderColor: '#f96',
+    backgroundColor: '#f966',
+  },
+  green: {
+    borderColor: '#9f9',
+    backgroundColor: '#9b96',
+  },
+  white: {
+    borderColor: '#eee',
+    backgroundColor: '#eee6',
+  },
+  black: {
+    borderColor: '#242229',
+    backgroundColor: '#24222966',
+  }
+};
 export default Alert;

--- a/src/pages/modules/util/useGlobalValues.js
+++ b/src/pages/modules/util/useGlobalValues.js
@@ -17,6 +17,7 @@ const useGlobalValues = () => {
         type: 'RESET_ALERT',
       }
     */
+    // console.info(`Global context reducer: ${action.type}`, action.data);
     if (action.type === 'ALERT') {
       return {
         ...state,
@@ -29,6 +30,7 @@ const useGlobalValues = () => {
       return {
         ...state,
         alertData: {
+          ...state.alertData,
           active: false,
         },
       };


### PR DESCRIPTION
### Added
 * Users can now use Shift+Delete and Ctrl+Delete to delete individual queries or their entire search cache respectively (while on the search page)
 * Users are warned when looking at a cached search result
 * Alert component now also exports a `presets` variable containing basic color presets for the alert coloring.
 * Alerts now support a `duration` param
 * (Bugfix) Alerts no longer lose their custom styling when fading out

### Breaking changes
 * `useShiftModifier` renamed to `useKeyModifiers` and now supports control modifiers via `isCtrling`.

### To add in other issues
- [x] Note *how* old a query is and display the "cached search result warning" only when that time gap exceeds some amount (1-3 months?) (#6)