### PR TITLE
Handle invalid / bad requests gracefully

### DIFF
--- a/src/pages/modules/MainPhase/submodules/DataForm.js
+++ b/src/pages/modules/MainPhase/submodules/DataForm.js
@@ -14,6 +14,7 @@ import generateQueryJson from '../../util/generateQueryJson';
 
 import './DataForm.css';
 import GlobalContext from '../../util/GlobalContext';
+import { presets } from '../../util/Alert';
 
 const DataForm = ({
   title, image, color, type, token, mediaId, transitionCallback, presetProgress, presetScore,
@@ -27,6 +28,20 @@ const DataForm = ({
   /* Get current media status color or default to black */
   const currentMediaColor = useCallback((override = status) => MEDIA_STATUS_COLORS[override] || '#222', [status]);
 
+  const handleBadRequest = useCallback(() => {
+    setGlobalValues({
+      type: 'ALERT',
+      data: {
+        active: true,
+        content: 'Something went wrong with the request. The page will automatically refresh in 2 seconds.',
+        duration: 2000,
+        style: presets.red,
+      },
+    });
+    setTimeout(() => {
+      window.location.reload();
+    }, 2000);
+  }, [setGlobalValues]);
 
   const switchMediaMode = useCallback((newStatus) => {
     setStatus(newStatus);
@@ -60,11 +75,12 @@ const DataForm = ({
       }), token);
       fetch(ANILIST_BASE_URL, options)
         .then((resp) => resp.json())
-        .then(() => {
-          transitionCallback(); // return to search phase
-        });
+        .then((resp) => (resp.ok
+          ? transitionCallback() // return to search phase
+          : handleBadRequest()))
+        .catch(handleBadRequest);
     }
-  }, [mediaId, progress, score, status, switchMediaMode, token, transitionCallback]);
+  }, [handleBadRequest, mediaId, progress, score, status, switchMediaMode, token, transitionCallback]);
 
   /* Event handling setup and initial form focus */
   useEffect(() => {

--- a/src/pages/modules/MainPhase/submodules/SearchPhase/SearchPhase.js
+++ b/src/pages/modules/MainPhase/submodules/SearchPhase/SearchPhase.js
@@ -79,6 +79,21 @@ const SearchPhase = ({ transitionCallback, token, type }) => {
     return newState;
   }, JSON.parse(localStorage.getItem('cachedResults')) || {});
 
+  const handleBadRequest = useCallback(() => {
+    setGlobalValues({
+      type: 'ALERT',
+      data: {
+        active: true,
+        content: 'Something went wrong with the request. The page will automatically refresh in 2 seconds.',
+        duration: 2000,
+        style: presets.red,
+      },
+    });
+    setTimeout(() => {
+      window.location.reload();
+    }, 2000);
+  }, [setGlobalValues]);
+
   const selectMediaIndex = useCallback((index) => {
     if (!searchResults[index] || Object.keys(searchResults[index]).length === 0) {
       return; // Likely we tried to select something that isnt present on the last page of the search
@@ -138,8 +153,9 @@ const SearchPhase = ({ transitionCallback, token, type }) => {
         searchResultParse(resp, {
           page, direction, cachedSearchResults,
         });
-      });
-  }, [searchResultParse, cachedSearchResults, search, page]);
+      })
+      .catch(handleBadRequest);
+  }, [search, page, cachedSearchResults, handleBadRequest, setGlobalValues, searchResultParse]);
 
   const changeSearchPage = useCallback((direction, baseQueryCallback) => {
     if (page + direction < 1 || page + direction > searchPages) return; // No page 0s or extra queries :)

--- a/src/pages/modules/MainPhase/submodules/SearchPhase/__tests__/SearchPhase.test.js
+++ b/src/pages/modules/MainPhase/submodules/SearchPhase/__tests__/SearchPhase.test.js
@@ -67,6 +67,46 @@ describe('search phase tests', () => {
     expect(pageProgCircles[0]).toHaveClass('activePage');
   });
 
+  it('refreshes on failed anilist response', async () => {
+    jest.useFakeTimers();
+
+    const { callbackFn, input } = setup();
+    window.location.reload = jest.fn();
+    await act(async () => {
+      fetch.mockResponseOnce({ ok: false });
+      fireEvent.change(input, { target: { value: 'TEST' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+    });
+    expect(fetch.mock.calls.length).toBe(1);
+    expect(callbackFn).not.toHaveBeenCalled();
+
+    setTimeout(() => {
+      expect(window.location.reload).toHaveBeenCalled();
+    }, 2500);
+
+    jest.runAllTimers();
+  });
+
+  it('refreshes on failed fetch', async () => {
+    jest.useFakeTimers();
+
+    const { callbackFn, input } = setup();
+    window.location.reload = jest.fn();
+    await act(async () => {
+      fetch.mockReject(new Error('fake error'));
+      fireEvent.change(input, { target: { value: 'TEST' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+    });
+    expect(fetch.mock.calls.length).toBe(1);
+    expect(callbackFn).not.toHaveBeenCalled();
+
+    setTimeout(() => {
+      expect(window.location.reload).toHaveBeenCalled();
+    }, 2500);
+
+    jest.runAllTimers();
+  });
+
   it('shifts the page on arrow keypress', async () => {
     const { container, input } = setup();
     await act(async () => {


### PR DESCRIPTION
When a request fails via external means (DNS failure, no internet connection) or anilist decline (500, server downtime), it will stop processing and display an error message then refresh the page after 2 seconds.