### PR TITLE
Differentiate cached results by media type

### DIFF
--- a/src/pages/modules/MainPhase/__tests__/MainPhase.test.js
+++ b/src/pages/modules/MainPhase/__tests__/MainPhase.test.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import {
+  render,
+  fireEvent,
+  act,
+  waitForElement,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import fetch from 'jest-fetch-mock';
+import MainPhase from '../MainPhase';
+import { SEARCH_PHASE_MOCK_RESPONSE, SEARCH_PHASE_MOCK_RESPONSE_PARTIAL } from '../../util/const';
+import GlobalContext from '../../util/GlobalContext';
+
+const wait = async (dur) => { await new Promise((r) => setTimeout(r, dur)); };
+
+describe('MainPhase.js', () => {
+  const setup = () => {
+    const setGlobalCallbackFn = jest.fn();
+    const { container } = render(
+      <GlobalContext.Provider
+        value={{
+          globalValues: {},
+          setGlobalValues: setGlobalCallbackFn,
+        }}
+      >
+        <MainPhase
+          token="123123"
+          mainState="entering"
+          userId="123"
+          username="321"
+        />
+      </GlobalContext.Provider>,
+    );
+    return { container };
+  };
+
+  it('differentiates search caching between different media types', async () => {
+    const { container } = setup();
+
+    // Enter page and press A to select anime media
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'a', code: 65 });
+    });
+    // Then we wait for the search field to be found post-transition
+    let input = await waitForElement(() => container.querySelector('input#search-input'));
+    expect(input).not.toBeNull();
+
+    // Afterwards, we mock a fetch and input "TEST" query
+    await act(async () => {
+      fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
+      fireEvent.change(input, { target: { value: 'TEST' } });
+    });
+    fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+
+    // Then we wait for data phase to be loaded and check localStorage
+    await waitForElement(() => container.querySelector('#data-phase'));
+    console.log(JSON.parse(window.localStorage.getItem('cachedResults')));
+    expect(JSON.parse(window.localStorage.getItem('cachedResults')).ANIME.TEST).toBeDefined();
+    expect(fetch.mock.calls.length).toBe(1);
+
+    // Return to media selection via Shift+CapsLock keybind
+    await act(async () => {
+      fireEvent.keyDown(container, { key: 'Shift', code: 16 });
+    });
+    fireEvent.keyDown(container, { key: 'CapsLock', code: 20 });
+
+    // Then select manga media type this time
+    await waitForElement(() => document.querySelector('.aom-a'));
+    await act(async () => {
+      fireEvent.keyDown(container, { key: 'm', code: 77 });
+    });
+
+    // Wait for search phase to render again...
+    input = await waitForElement(() => container.querySelector('input#search-input'));
+    expect(input).not.toBeNull();
+
+    // And repeat above, searching for "TEST" again
+    await act(async () => {
+      fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE_PARTIAL));
+      fireEvent.change(input, { target: { value: 'TEST' } });
+    });
+    fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+
+    // Then we check for the same query as before but in the manga cache
+    await waitForElement(() => container.querySelector('#data-phase'));
+    console.log(window.localStorage);
+    expect(JSON.parse(window.localStorage.getItem('cachedResults')).MANGA.TEST).toBeDefined();
+    expect(fetch.mock.calls.length).toBe(2);
+  });
+});

--- a/src/pages/modules/MainPhase/submodules/SearchPhase/__tests__/SearchPhase.test.js
+++ b/src/pages/modules/MainPhase/submodules/SearchPhase/__tests__/SearchPhase.test.js
@@ -51,180 +51,180 @@ describe('search phase tests', () => {
     expect(container.querySelector('#page-prog-container')).toBeNull();
   });
 
-  // TESTS THAT UTILIZE FETCH MOCKS START HERE //
-  // NON-ATOMIC TESTS //
-  it('loads all page elements when good search sent', async () => {
-    const { container, input } = setup();
-    await act(async () => {
-      fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
-      fireEvent.change(input, { target: { value: 'TEST' } });
-      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+  describe('fetch mocking', () => {
+    it('loads all page elements when good search sent', async () => {
+      const { container, input } = setup();
+      await act(async () => {
+        fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
+        fireEvent.change(input, { target: { value: 'TEST' } });
+        fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+      });
+      expect(container.querySelector('#page-prog-container')).toBeDefined();
+      expect(container.querySelectorAll('#results-item').length).toBe(4);
+      const pageProgCircles = container.querySelectorAll('#page-prog-container .page-prog-circle');
+      expect(pageProgCircles.length).toBe(2);
+      expect(pageProgCircles[0]).toHaveClass('activePage');
     });
-    expect(container.querySelector('#page-prog-container')).toBeDefined();
-    expect(container.querySelectorAll('#results-item').length).toBe(4);
-    const pageProgCircles = container.querySelectorAll('#page-prog-container .page-prog-circle');
-    expect(pageProgCircles.length).toBe(2);
-    expect(pageProgCircles[0]).toHaveClass('activePage');
-  });
 
-  it('refreshes on failed anilist response', async () => {
-    jest.useFakeTimers();
+    it('refreshes on failed anilist response', async () => {
+      jest.useFakeTimers();
 
-    const { callbackFn, input } = setup();
-    window.location.reload = jest.fn();
-    await act(async () => {
-      fetch.mockResponseOnce({ ok: false });
-      fireEvent.change(input, { target: { value: 'TEST' } });
-      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
-    });
-    expect(fetch.mock.calls.length).toBe(1);
-    expect(callbackFn).not.toHaveBeenCalled();
+      const { callbackFn, input } = setup();
+      window.location.reload = jest.fn();
+      await act(async () => {
+        fetch.mockResponseOnce({ ok: false });
+        fireEvent.change(input, { target: { value: 'TEST' } });
+        fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+      });
+      expect(fetch.mock.calls.length).toBe(1);
+      expect(callbackFn).not.toHaveBeenCalled();
 
-    setTimeout(() => {
-      expect(window.location.reload).toHaveBeenCalled();
-    }, 2500);
+      setTimeout(() => {
+        expect(window.location.reload).toHaveBeenCalled();
+      }, 2500);
 
-    jest.runAllTimers();
-  });
+      jest.runAllTimers();
+    });
 
-  it('refreshes on failed fetch', async () => {
-    jest.useFakeTimers();
+    it('refreshes on failed fetch', async () => {
+      jest.useFakeTimers();
 
-    const { callbackFn, input } = setup();
-    window.location.reload = jest.fn();
-    await act(async () => {
-      fetch.mockReject(new Error('fake error'));
-      fireEvent.change(input, { target: { value: 'TEST' } });
-      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
-    });
-    expect(fetch.mock.calls.length).toBe(1);
-    expect(callbackFn).not.toHaveBeenCalled();
+      const { callbackFn, input } = setup();
+      window.location.reload = jest.fn();
+      await act(async () => {
+        fetch.mockReject(new Error('fake error'));
+        fireEvent.change(input, { target: { value: 'TEST' } });
+        fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+      });
+      expect(fetch.mock.calls.length).toBe(1);
+      expect(callbackFn).not.toHaveBeenCalled();
 
-    setTimeout(() => {
-      expect(window.location.reload).toHaveBeenCalled();
-    }, 2500);
+      setTimeout(() => {
+        expect(window.location.reload).toHaveBeenCalled();
+      }, 2500);
 
-    jest.runAllTimers();
-  });
+      jest.runAllTimers();
+    });
 
-  it('shifts the page on arrow keypress', async () => {
-    const { container, input } = setup();
-    await act(async () => {
-      fetch.mockResponse(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
-      fireEvent.change(input, { target: { value: 'TEST' } });
-      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+    it('shifts the page on arrow keypress', async () => {
+      const { container, input } = setup();
+      await act(async () => {
+        fetch.mockResponse(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
+        fireEvent.change(input, { target: { value: 'TEST' } });
+        fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+      });
+      await act(async () => {
+        fireEvent.keyDown(input, { key: 'ArrowRight', code: 39 });
+      });
+      const pageProgCircles = container.querySelectorAll('#page-prog-container .page-prog-circle');
+      expect(pageProgCircles[1]).toHaveClass('activePage');
+      expect(pageProgCircles[0]).toHaveClass('pastPage');
     });
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'ArrowRight', code: 39 });
-    });
-    const pageProgCircles = container.querySelectorAll('#page-prog-container .page-prog-circle');
-    expect(pageProgCircles[1]).toHaveClass('activePage');
-    expect(pageProgCircles[0]).toHaveClass('pastPage');
-  });
 
-  it('does not shift if at page 1', async () => {
-    const { container, input } = setup();
-    await act(async () => {
-      fetch.mockResponse(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
-      fireEvent.change(input, { target: { value: 'TEST' } });
-      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+    it('does not shift if at page 1', async () => {
+      const { container, input } = setup();
+      await act(async () => {
+        fetch.mockResponse(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
+        fireEvent.change(input, { target: { value: 'TEST' } });
+        fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+      });
+      await act(async () => {
+        fireEvent.keyDown(input, { key: 'ArrowLeft', code: 37 });
+      });
+      const pageProgCircles = container.querySelectorAll('#page-prog-container .page-prog-circle');
+      expect(pageProgCircles[0]).toHaveClass('activePage');
+      expect(pageProgCircles[1]).not.toHaveClass('activePage');
     });
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'ArrowLeft', code: 37 });
-    });
-    const pageProgCircles = container.querySelectorAll('#page-prog-container .page-prog-circle');
-    expect(pageProgCircles[0]).toHaveClass('activePage');
-    expect(pageProgCircles[1]).not.toHaveClass('activePage');
-  });
 
-  it('selects media 1 when F1 is pressed', async () => {
-    const { callbackFn, input } = setup();
-    await act(async () => {
-      fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
-      fireEvent.change(input, { target: { value: 'TEST' } });
-      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+    it('selects media 1 when F1 is pressed', async () => {
+      const { callbackFn, input } = setup();
+      await act(async () => {
+        fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
+        fireEvent.change(input, { target: { value: 'TEST' } });
+        fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+      });
+      await act(async () => {
+        fireEvent.keyDown(input, { key: 'F1', code: 112 });
+      });
+      const expectedParam = SEARCH_PHASE_MOCK_RESPONSE.data.Page.media[0];
+      expect(callbackFn).toHaveBeenCalledWith(expectedParam);
     });
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'F1', code: 112 });
-    });
-    const expectedParam = SEARCH_PHASE_MOCK_RESPONSE.data.Page.media[0];
-    expect(callbackFn).toHaveBeenCalledWith(expectedParam);
-  });
 
-  it('selects media 2 when F2 is pressed', async () => {
-    const { callbackFn, input } = setup();
-    await act(async () => {
-      fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
-      fireEvent.change(input, { target: { value: 'TEST' } });
-      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+    it('selects media 2 when F2 is pressed', async () => {
+      const { callbackFn, input } = setup();
+      await act(async () => {
+        fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
+        fireEvent.change(input, { target: { value: 'TEST' } });
+        fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+      });
+      await act(async () => {
+        fireEvent.keyDown(input, { key: 'F2', code: 113 });
+      });
+      const expectedParam = SEARCH_PHASE_MOCK_RESPONSE.data.Page.media[1];
+      expect(callbackFn).toHaveBeenCalledWith(expectedParam);
     });
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'F2', code: 113 });
-    });
-    const expectedParam = SEARCH_PHASE_MOCK_RESPONSE.data.Page.media[1];
-    expect(callbackFn).toHaveBeenCalledWith(expectedParam);
-  });
 
-  it('selects media 3 when F3 is pressed', async () => {
-    const { callbackFn, input } = setup();
-    await act(async () => {
-      fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
-      fireEvent.change(input, { target: { value: 'TEST' } });
-      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+    it('selects media 3 when F3 is pressed', async () => {
+      const { callbackFn, input } = setup();
+      await act(async () => {
+        fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
+        fireEvent.change(input, { target: { value: 'TEST' } });
+        fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+      });
+      await act(async () => {
+        fireEvent.keyDown(input, { key: 'F3', code: 114 });
+      });
+      const expectedParam = SEARCH_PHASE_MOCK_RESPONSE.data.Page.media[2];
+      expect(callbackFn).toHaveBeenCalledWith(expectedParam);
     });
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'F3', code: 114 });
-    });
-    const expectedParam = SEARCH_PHASE_MOCK_RESPONSE.data.Page.media[2];
-    expect(callbackFn).toHaveBeenCalledWith(expectedParam);
-  });
 
-  it('selects media 4 when F4 is pressed', async () => {
-    const { callbackFn, input } = setup();
-    await act(async () => {
-      fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
-      fireEvent.change(input, { target: { value: 'TEST' } });
-      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+    it('selects media 4 when F4 is pressed', async () => {
+      const { callbackFn, input } = setup();
+      await act(async () => {
+        fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
+        fireEvent.change(input, { target: { value: 'TEST' } });
+        fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+      });
+      await act(async () => {
+        fireEvent.keyDown(input, { key: 'F4', code: 115 });
+      });
+      const expectedParam = SEARCH_PHASE_MOCK_RESPONSE.data.Page.media[3];
+      expect(callbackFn).toHaveBeenCalledWith(expectedParam);
     });
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'F4', code: 115 });
-    });
-    const expectedParam = SEARCH_PHASE_MOCK_RESPONSE.data.Page.media[3];
-    expect(callbackFn).toHaveBeenCalledWith(expectedParam);
-  });
 
-  it('does nothing when selecting a media that is not present', async () => {
-    const { callbackFn, input, container } = setup();
-    await act(async () => {
-      fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE_PARTIAL));
-      fireEvent.change(input, { target: { value: 'TEST' } });
-      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+    it('does nothing when selecting a media that is not present', async () => {
+      const { callbackFn, input, container } = setup();
+      await act(async () => {
+        fetch.mockResponseOnce(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE_PARTIAL));
+        fireEvent.change(input, { target: { value: 'TEST' } });
+        fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+      });
+      expect(container.querySelectorAll('#results-item').length).toBe(1);
+      await act(async () => {
+        fireEvent.keyDown(input, { key: 'F2', code: 113 });
+      });
+      expect(callbackFn).not.toHaveBeenCalled();
     });
-    expect(container.querySelectorAll('#results-item').length).toBe(1);
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'F2', code: 113 });
-    });
-    expect(callbackFn).not.toHaveBeenCalled();
-  });
 
-  it('doesnt fetch unnecessarily for cached views', async () => {
-    const { input } = setup();
-    expect(fetch.mock.calls.length).toBe(0);
-    await act(async () => {
-      fetch.mockResponse(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
-      fireEvent.change(input, { target: { value: 'TEST' } });
+    it('doesnt fetch unnecessarily for cached views', async () => {
+      const { input } = setup();
+      expect(fetch.mock.calls.length).toBe(0);
+      await act(async () => {
+        fetch.mockResponse(JSON.stringify(SEARCH_PHASE_MOCK_RESPONSE));
+        fireEvent.change(input, { target: { value: 'TEST' } });
+      });
+      await act(async () => {
+        fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+      });
+      expect(fetch.mock.calls.length).toBe(1);
+      await act(async () => {
+        fireEvent.keyDown(input, { key: 'ArrowRight', code: 39 });
+      });
+      expect(fetch.mock.calls.length).toBe(2);
+      await act(async () => {
+        fireEvent.keyDown(input, { key: 'ArrowLeft', code: 37 });
+      });
+      expect(fetch.mock.calls.length).toBe(2);
     });
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
-    });
-    expect(fetch.mock.calls.length).toBe(1);
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'ArrowRight', code: 39 });
-    });
-    expect(fetch.mock.calls.length).toBe(2);
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'ArrowLeft', code: 37 });
-    });
-    expect(fetch.mock.calls.length).toBe(2);
   });
 });

--- a/src/pages/modules/MainPhase/submodules/SearchPhase/submodules/SearchItem.js
+++ b/src/pages/modules/MainPhase/submodules/SearchPhase/submodules/SearchItem.js
@@ -85,8 +85,8 @@ SearchItem.propTypes = {
   showTitle: PropTypes.bool,
   index: PropTypes.number.isRequired,
   isFlatView: PropTypes.bool.isRequired,
-  progress: PropTypes.string.isRequired,
-  maxProgress: PropTypes.string.isRequired,
+  progress: PropTypes.number.isRequired,
+  maxProgress: PropTypes.number.isRequired,
 };
 
 SearchItem.defaultProps = {


### PR DESCRIPTION
Additional fixes
 * Fixed a bug where if you were on a page N > 1 and switched search terms, it would cache the results of that new query's page 1 as their page N.