### PR TITLE
Rate limit on new queries

### DIFF
--- a/src/pages/modules/MainPhase/MainPhase.test.js
+++ b/src/pages/modules/MainPhase/MainPhase.test.js
@@ -58,6 +58,7 @@ describe('MainPhase.js', () => {
       fireEvent.change(input, { target: { value: 'TEST' } });
     });
     fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+    localStorage.removeItem('lastSearch'); // We have a rate limit of 2s per request -- avoid it in tests
 
     // Then we wait for data phase to be loaded and check localStorage
     await waitForElement(() => container.querySelector('#data-phase'));

--- a/src/pages/modules/util/const.js
+++ b/src/pages/modules/util/const.js
@@ -1,3 +1,4 @@
+export const LOCAL_RATE_LIMIT = 2000; // 2 seconds;
 export const VERIFICATION_QUERY = `query {
   Viewer {
     id


### PR DESCRIPTION
closes #24 

pretty self explanatory, introduces a 2s CD for the search phase. does not apply to cached search results.