### PR TITLE
Remove PropTypes

### DIFF
--- a/src/pages/modules/Avatar/Avatar.tsx
+++ b/src/pages/modules/Avatar/Avatar.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import ReactTooltip from 'react-tooltip';
 
 import './Avatar.scss';
@@ -27,10 +26,6 @@ const Avatar = ({ image = '' }): React.ReactElement => {
       />
     </>
   );
-};
-
-Avatar.propTypes = {
-  image: PropTypes.string,
 };
 
 export default Avatar;

--- a/src/pages/modules/LoginPhase/LoginPhase.tsx
+++ b/src/pages/modules/LoginPhase/LoginPhase.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
 import { useSpring, animated } from 'react-spring';
 import TokenInput from './submodules/TokenInput/TokenInput';
 import LoginButton from './submodules/LoginButton/LoginButton';
@@ -49,11 +48,6 @@ const LoginPhase = ({ loginState, width, submitCallback }: LPProps): React.React
       </animated.div>
     </>
   );
-};
-LoginPhase.propTypes = {
-  loginState: PropTypes.string.isRequired,
-  width: PropTypes.number.isRequired,
-  submitCallback: PropTypes.func.isRequired,
 };
 
 export default LoginPhase;

--- a/src/pages/modules/LoginPhase/submodules/LoginButton/LoginButton.tsx
+++ b/src/pages/modules/LoginPhase/submodules/LoginButton/LoginButton.tsx
@@ -1,5 +1,4 @@
 import React, { CSSProperties } from 'react';
-import PropTypes from 'prop-types';
 
 import './LoginButton.scss';
 
@@ -13,11 +12,5 @@ const LoginButton = ({ style = {}, redirect, content }: LBProps): React.ReactEle
     <a href={redirect}>{content}</a>
   </div>
 );
-
-LoginButton.propTypes = {
-  style: PropTypes.object,
-  redirect: PropTypes.string.isRequired,
-  content: PropTypes.string.isRequired,
-};
 
 export default LoginButton;

--- a/src/pages/modules/LoginPhase/submodules/TokenInput/TokenInput.tsx
+++ b/src/pages/modules/LoginPhase/submodules/TokenInput/TokenInput.tsx
@@ -2,8 +2,6 @@ import React, { useState, useEffect, useReducer, useCallback } from 'react';
 import { useSpring, animated } from 'react-spring';
 import { IoIosCheckmark } from 'react-icons/io';
 
-import PropTypes from 'prop-types';
-
 import generateQueryJson from 'Utils/generateQueryJson';
 import * as consts from 'Utils/const';
 import { InitialQuery } from 'interfaces/interfaces';
@@ -136,7 +134,3 @@ const TokenInput = ({ callback }: TIProps): React.ReactElement => {
 };
 
 export default TokenInput;
-
-TokenInput.propTypes = {
-  callback: PropTypes.func.isRequired,
-};

--- a/src/pages/modules/Logo/Logo.tsx
+++ b/src/pages/modules/Logo/Logo.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { animated, useSpring } from 'react-spring';
 
 import './Logo.scss';
@@ -23,10 +22,6 @@ const Logo = ({ mainState }: LProps): React.ReactElement => {
       }}
     />
   );
-};
-
-Logo.propTypes = {
-  mainState: PropTypes.string.isRequired,
 };
 
 export default Logo;

--- a/src/pages/modules/MainPhase/MainPhase.tsx
+++ b/src/pages/modules/MainPhase/MainPhase.tsx
@@ -1,6 +1,5 @@
 /* Libraries */
 import React, { useState, useCallback, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import { useSpring, animated } from 'react-spring';
 
 /* Modules */
@@ -134,12 +133,6 @@ const MainPhase = ({ token, mainState, username = '' }: MPProps): React.ReactEle
       </div>
     </>
   );
-};
-
-MainPhase.propTypes = {
-  token: PropTypes.string.isRequired,
-  mainState: PropTypes.string.isRequired,
-  username: PropTypes.string,
 };
 
 export default MainPhase;

--- a/src/pages/modules/MainPhase/submodules/DataForm/DataForm.tsx
+++ b/src/pages/modules/MainPhase/submodules/DataForm/DataForm.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback, useContext } from 'react';
-// import PropTypes from 'prop-types';
 import {
   MEDIA_STATUS_COLORS,
   MEDIA_TYPE_SINGLETON_TERM,
@@ -132,14 +131,6 @@ const DataForm = ({
   return (
     <>
       <div id="data-form-container">
-        {/* <Alert
-          active={alertActive}
-          content={alertActive}
-          style={{
-            border: `1px solid ${currentMediaColor()}`,
-            backgroundColor: `${currentMediaColor()}3`,
-          }}
-        /> */}
         <div
           id="data-form-image"
           style={{
@@ -187,17 +178,5 @@ const DataForm = ({
     </>
   );
 };
-
-// DataForm.propTypes = {
-//   title: PropTypes.string.isRequired,
-//   image: PropTypes.string.isRequired,
-//   color: PropTypes.string.isRequired,
-//   type: PropTypes.string.isRequired,
-//   token: PropTypes.string.isRequired,
-//   mediaId: PropTypes.number.isRequired,
-//   transitionCallback: PropTypes.func.isRequired,
-//   presetProgress: PropTypes.number,
-//   presetScore: PropTypes.number,
-// };
 
 export default DataForm;

--- a/src/pages/modules/MainPhase/submodules/HelpMessage/HelpMessage.tsx
+++ b/src/pages/modules/MainPhase/submodules/HelpMessage/HelpMessage.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useSpring, animated } from 'react-spring';
 import { IoIosInformationCircleOutline } from 'react-icons/io';
 
@@ -29,12 +28,6 @@ const HelpMessage = ({ substate = '', prevSubstate = '', helpMap }: HMProps): Re
   ) : (
     <></>
   );
-};
-
-HelpMessage.propTypes = {
-  substate: PropTypes.string.isRequired,
-  prevSubstate: PropTypes.string.isRequired,
-  helpMap: PropTypes.object.isRequired,
 };
 
 export default HelpMessage;

--- a/src/pages/modules/MainPhase/submodules/SearchPhase/SearchPhase.tsx
+++ b/src/pages/modules/MainPhase/submodules/SearchPhase/SearchPhase.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback, useReducer, useContext } from 'react';
-import PropTypes from 'prop-types';
 import { IoIosSearch } from 'react-icons/io';
 
 import SearchItem from './submodules/SearchItem/SearchItem';
@@ -347,12 +346,6 @@ const SearchPhase = ({ transitionCallback, token = '', type = '' }: SPProps): Re
       </div>
     </>
   );
-};
-
-SearchPhase.propTypes = {
-  transitionCallback: PropTypes.func.isRequired,
-  token: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
 };
 
 export default SearchPhase;

--- a/src/pages/modules/MainPhase/submodules/SearchPhase/submodules/PageProgression/PageProgression.tsx
+++ b/src/pages/modules/MainPhase/submodules/SearchPhase/submodules/PageProgression/PageProgression.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import './PageProgression.scss';
 
 const PageProgression = ({ maxPages = 0, page = 0 }): React.ReactElement =>
@@ -31,10 +30,5 @@ const PageProgression = ({ maxPages = 0, page = 0 }): React.ReactElement =>
       </div>
     </div>
   );
-
-PageProgression.propTypes = {
-  maxPages: PropTypes.number,
-  page: PropTypes.number,
-};
 
 export default PageProgression;

--- a/src/pages/modules/MainPhase/submodules/SearchPhase/submodules/SearchItem/SearchItem.tsx
+++ b/src/pages/modules/MainPhase/submodules/SearchPhase/submodules/SearchItem/SearchItem.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import { useSpring, animated } from 'react-spring';
 
 import './SearchItem.scss';
@@ -70,13 +69,3 @@ const SearchItem = ({
 };
 
 export default SearchItem;
-
-SearchItem.propTypes = {
-  color: PropTypes.string.isRequired,
-  coverImage: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
-  index: PropTypes.number.isRequired,
-  isFlatView: PropTypes.bool.isRequired,
-  progress: PropTypes.number.isRequired,
-  maxProgress: PropTypes.number.isRequired,
-};


### PR DESCRIPTION
Closes #49 

With TypeScript brought into our pipeline, we no longer need PropTypes for type checking -- it only clogs up our run time with unnecessary processes.