### PR TITLE
Fix false negative when submitting media list updates

### DIFF
--- a/src/pages/modules/MainPhase/submodules/DataForm/DataForm.test.js
+++ b/src/pages/modules/MainPhase/submodules/DataForm/DataForm.test.js
@@ -97,7 +97,7 @@ describe('data phase tests', () => {
   });
 
   it('posts data to anilist on Enter', async () => {
-    fetch.mockResponseOnce(JSON.stringify({ ok: true }));
+    fetch.mockResponseOnce(JSON.stringify({ data: { SaveMediaListEntry: { id: 1 } } }));
     const { container, callbackFn } = setup({ presetProgress: 12 });
     await act(async () => {
       fireEvent.keyDown(container, { key: 'Enter', code: 13 });

--- a/src/pages/modules/MainPhase/submodules/DataForm/DataForm.tsx
+++ b/src/pages/modules/MainPhase/submodules/DataForm/DataForm.tsx
@@ -49,7 +49,7 @@ const DataForm = ({
   );
 
   const handleBadRequest = useCallback((e): void => {
-    console.error(e)
+    // console.error(e)
     setGlobalValues &&
       setGlobalValues({
         type: 'ALERT',
@@ -61,7 +61,7 @@ const DataForm = ({
         },
       });
     setTimeout(() => {
-      // window.location.reload();
+      window.location.reload();
     }, 2000);
   }, [setGlobalValues]);
 

--- a/src/pages/modules/MainPhase/submodules/DataForm/DataForm.tsx
+++ b/src/pages/modules/MainPhase/submodules/DataForm/DataForm.tsx
@@ -48,7 +48,8 @@ const DataForm = ({
     [status],
   );
 
-  const handleBadRequest = useCallback((): void => {
+  const handleBadRequest = useCallback((e): void => {
+    console.error(e)
     setGlobalValues &&
       setGlobalValues({
         type: 'ALERT',
@@ -60,7 +61,7 @@ const DataForm = ({
         },
       });
     setTimeout(() => {
-      window.location.reload();
+      // window.location.reload();
     }, 2000);
   }, [setGlobalValues]);
 
@@ -109,9 +110,9 @@ const DataForm = ({
         fetch(ANILIST_BASE_URL, options)
           .then(resp => resp.json())
           .then(resp =>
-            resp.ok
+            resp.data && resp.data.SaveMediaListEntry && resp.data.SaveMediaListEntry.id
               ? transitionCallback() // return to search phase
-              : handleBadRequest(),
+              : handleBadRequest(resp),
           )
           .catch(handleBadRequest);
       }
@@ -151,7 +152,7 @@ const DataForm = ({
             <input
               id="data-form-media-count-value"
               type="text"
-              pattern="[1-9]"
+              pattern="[1-9]+"
               value={progress || ''}
               onChange={(e): void => setProgress(+e.target.value)}
               placeholder={`${MEDIA_TYPE_SINGLETON_TERM[type]}s`}


### PR DESCRIPTION
Media list updates were triggering the "something went wrong" dialog and refreshed the page despite them working.

This is due to a misunderstanding in the response of the the mutation query and has been fixed.

*Also fixed*:
 * The episode/chapter field would get a red border when using a value over 9, this was due to an incorrect mask for the input field.